### PR TITLE
Caching Programme Budgets

### DIFF
--- a/budgetportal/openspending.py
+++ b/budgetportal/openspending.py
@@ -11,7 +11,7 @@ import re
 
 logger = logging.getLogger(__name__)
 
-PAGE_SIZE = 300
+PAGE_SIZE = 10000
 
 
 class EstimatesOfExpenditure():

--- a/budgetportal/openspending.py
+++ b/budgetportal/openspending.py
@@ -121,6 +121,15 @@ class EstimatesOfExpenditure():
             raise Exception("More cells than expected - perhaps we should start paging")
         return aggregate_result.json()
 
+    def filter_dept(self, result, dept_name, sphere):
+        sphere_filter = {
+            'national': 'vote_number.department',
+            'provincial': 'department.department'
+        }
+        filtered_results = filter(
+            lambda x: x[sphere_filter[sphere]] == dept_name, result['cells'])
+        return {'cells': filtered_results}
+
 
 def cube_url(model_url):
     return re.sub('model/?$', '', model_url)

--- a/budgetportal/openspending.py
+++ b/budgetportal/openspending.py
@@ -121,13 +121,15 @@ class EstimatesOfExpenditure():
             raise Exception("More cells than expected - perhaps we should start paging")
         return aggregate_result.json()
 
-    def filter_dept(self, result, dept_name, sphere):
+    def filter_dept(self, result, dept_name, sphere, financial_year):
         sphere_filter = {
             'national': 'vote_number.department',
             'provincial': 'department.department'
         }
-        filtered_results = filter(
-            lambda x: x[sphere_filter[sphere]] == dept_name, result['cells'])
+        filtered_results = []
+        for budget in result['cells']:
+            if budget[sphere_filter[sphere]] == dept_name and budget['financial_year.financial_year'] == financial_year:
+                filtered_results.append(budget)
         return {'cells': filtered_results}
 
 


### PR DESCRIPTION
* On the provincial level, cache all the department programme budgets for a province across all years, then filter by year and department name
* In the national level, cache all department programme budgets for the year, then filter by department name